### PR TITLE
Avoiding exceptions when using NoopTracer

### DIFF
--- a/src/ConsumerTracingBehavior.cs
+++ b/src/ConsumerTracingBehavior.cs
@@ -13,14 +13,7 @@ namespace Silverback.Integration.OpenTracing
     {
         public async Task Handle(ConsumerPipelineContext context, IServiceProvider serviceProvider, ConsumerBehaviorHandler next)
         {
-            var envelope = context.Envelopes.SingleOrDefault();
-
-            if (GlobalTracer.Instance == null || envelope == null)
-            {
-                await next(context, serviceProvider);
-
-                return;
-            }
+            var envelope = context.Envelopes.Single();
 
             var operationName = $"Consuming Message on topic {envelope.Endpoint.Name}";
 

--- a/src/ProducerTracingBehavior.cs
+++ b/src/ProducerTracingBehavior.cs
@@ -10,7 +10,7 @@ namespace Silverback.Integration.OpenTracing
     {
         public async Task Handle(ProducerPipelineContext context, ProducerBehaviorHandler next)
         {
-            if (GlobalTracer.Instance == null || context.Envelope == null)
+            if (GlobalTracer.Instance?.ActiveSpan == null)
             {
                 await next(context);
 

--- a/src/ProducerTracingBehavior.cs
+++ b/src/ProducerTracingBehavior.cs
@@ -10,18 +10,25 @@ namespace Silverback.Integration.OpenTracing
     {
         public async Task Handle(ProducerPipelineContext context, ProducerBehaviorHandler next)
         {
+            if (GlobalTracer.Instance == null || context.Envelope == null)
+            {
+                await next(context);
+
+                return;
+            }
+
             var envelope = context.Envelope;
 
             var spanBuilder = GlobalTracer.Instance.BuildSpan($"Publish message on topic {envelope.Endpoint.Name}")
                    .WithTag(Tags.SpanKind, Tags.SpanKindProducer)
                    .WithTag("endpoint", envelope.Endpoint.Name);
 
-            using (var scope = spanBuilder.StartActive())
+            using (spanBuilder.StartActive())
             {
                 GlobalTracer.Instance.Inject(
-                   GlobalTracer.Instance.ActiveSpan.Context,
-                   BuiltinFormats.TextMap,
-                   new SilverbackTextMapInjectAdapter(envelope));
+                    GlobalTracer.Instance.ActiveSpan.Context,
+                    BuiltinFormats.TextMap,
+                    new SilverbackTextMapInjectAdapter(envelope));
 
                 await next(context);
             }

--- a/src/SilverbackTextMapInjectAdapter.cs
+++ b/src/SilverbackTextMapInjectAdapter.cs
@@ -9,11 +9,11 @@ namespace Silverback.Integration.OpenTracing
 {
     public class SilverbackTextMapInjectAdapter : ITextMap
     {
-        private IOutboundEnvelope envelope;
+        private readonly IOutboundEnvelope _envelope;
 
         public SilverbackTextMapInjectAdapter(IOutboundEnvelope envelope)
         {
-            this.envelope = envelope;
+            _envelope = envelope;
         }
 
         public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
@@ -24,7 +24,7 @@ namespace Silverback.Integration.OpenTracing
 
         public void Set(string key, string value)
         {
-            envelope.Headers.AddOrReplace(key, value);
+            _envelope.Headers.AddOrReplace(key, value);
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();


### PR DESCRIPTION
When there is a NoopTracer in the GlobalTracer.Instance the producer behavior will fail.

This adds a check to do nothing if there is no active span or no global tracer.